### PR TITLE
Add root privileges in Ubuntu 20.04

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -43,7 +43,7 @@ export LANGUAGE=en_US.UTF-8
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 locale-gen en_US.UTF-8
-dpkg-reconfigure locales
+sudo dpkg-reconfigure locales
 
 echo "--- Installing MONARC FO… ---"
 


### PR DESCRIPTION
Fixed the following error in the Ubuntu 20.04 script:
```bash
user@server:~$ dpkg-reconfigure locales
/usr/sbin/dpkg-reconfigure must be run as root
```